### PR TITLE
feat: 显示未入库的事件

### DIFF
--- a/giokit/src/main/java/com/growingio/giokit/launch/db/GioKitDbManager.kt
+++ b/giokit/src/main/java/com/growingio/giokit/launch/db/GioKitDbManager.kt
@@ -12,7 +12,7 @@ import com.growingio.giokit.utils.cleanOutDatedFile
  */
 class GioKitDbManager private constructor() {
 
-    private val EVENT_VALID_PERIOD_MILLS = 7L * 24 * 60 * 60000
+    private val EVENT_VALID_PERIOD_MILLS = 10L * 24 * 60 * 60000
     private val HTTP_VALID_PERIOD_MILLS = 24 * 60 * 60000L
 
     init {

--- a/giokit/src/main/java/com/growingio/giokit/launch/db/GioKitEventBean.java
+++ b/giokit/src/main/java/com/growingio/giokit/launch/db/GioKitEventBean.java
@@ -21,6 +21,8 @@ public class GioKitEventBean {
     public static final int STATUS_SENDED = 1;
     @Ignore
     public static final int STATUS_OUTDATE = -1;
+    @Ignore
+    public static final int STATUS_DROP = -2;
 
     @PrimaryKey(autoGenerate = true)
     private int id;
@@ -32,7 +34,7 @@ public class GioKitEventBean {
     private String type;
 
     @ColumnInfo(name = "status")
-    private int status;//0，1，-1=>未发送，已发送，过期
+    private int status;//0，1，-1, -2=>未发送，已发送，过期, 废弃
 
     @ColumnInfo(name = "data")
     private String data;//数据内容

--- a/giokit/src/main/java/com/growingio/giokit/launch/sdkdata/SdkDataAdapter.kt
+++ b/giokit/src/main/java/com/growingio/giokit/launch/sdkdata/SdkDataAdapter.kt
@@ -85,6 +85,16 @@ class SdkDataAdapter(val context: Context, val eventClick: (Int) -> Unit) :
                     "过期"
                 }
 
+                -2 -> {
+                    holder.statusTv.setTextColor(
+                        ContextCompat.getColor(
+                            context,
+                            R.color.hover_primary
+                        )
+                    )
+                    "丢弃"
+                }
+
                 else -> {
                     holder.statusTv.setTextColor(
                         ContextCompat.getColor(

--- a/giokit/src/main/java/com/growingio/giokit/launch/sdkdata/SdkDataAdapter.kt
+++ b/giokit/src/main/java/com/growingio/giokit/launch/sdkdata/SdkDataAdapter.kt
@@ -79,7 +79,7 @@ class SdkDataAdapter(val context: Context, val eventClick: (Int) -> Unit) :
                     holder.statusTv.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.hover_primary
+                            R.color.giokit_text_grey
                         )
                     )
                     "过期"
@@ -89,7 +89,7 @@ class SdkDataAdapter(val context: Context, val eventClick: (Int) -> Unit) :
                     holder.statusTv.setTextColor(
                         ContextCompat.getColor(
                             context,
-                            R.color.hover_primary
+                            R.color.giokit_text_grey
                         )
                     )
                     "丢弃"

--- a/giokit/src/main/res/layout/fragment_giokit_sdkdata_info.xml
+++ b/giokit/src/main/res/layout/fragment_giokit_sdkdata_info.xml
@@ -34,7 +34,7 @@
             android:textColor="@color/hover_accent"
             android:textSize="@dimen/giokit_text_title"
             android:textStyle="bold"
-            tools:text="又双叒叕一个Android客户端" />
+            tools:text="Json展示" />
 
     </RelativeLayout>
 
@@ -53,7 +53,7 @@
             android:focusable="true"
             android:longClickable="true"
             android:textIsSelectable="true"
-            tools:text="ajsfdhasdjhskjdhaskjdhaskd " />
+            tools:text="数据为空 " />
 
 
     </androidx.core.widget.NestedScrollView>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,8 +33,8 @@ powermock = "2.0.9"
 
 # !!! SDK VERSION !!!
 growingio = "4.2.0"
-growingioPlugin = "4.2.0"
-giokit = "2.1.0"
+growingioPlugin = "4.1.0"
+giokit = "2.1.1"
 giokitCode = "21"
 
 [plugins]


### PR DESCRIPTION
事件库中现在可以显示未入库的事件，这些事件通常由于一些原因导致无法入库从而无法发送，比如事件数据过大等。